### PR TITLE
Use SQLite backend instead of dummy data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+backend/node_modules/
+project/node_modules/
+*.db

--- a/backend/db.js
+++ b/backend/db.js
@@ -1,0 +1,34 @@
+import sqlite3 from 'sqlite3';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const dbPath = path.join(__dirname, 'jobs.db');
+const db = new sqlite3.Database(dbPath);
+
+// Initialize tables
+const init = () => {
+  db.serialize(() => {
+    db.run(`CREATE TABLE IF NOT EXISTS jobs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      title TEXT NOT NULL,
+      companyName TEXT NOT NULL,
+      location TEXT NOT NULL,
+      salary INTEGER,
+      jobPostedOn TEXT,
+      hiringMultipleCandidates TEXT,
+      niche TEXT
+    );`);
+
+    db.run(`CREATE TABLE IF NOT EXISTS users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      email TEXT UNIQUE,
+      password TEXT,
+      role TEXT
+    );`);
+  });
+};
+
+export { db, init };

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,54 @@
+import express from 'express';
+import cors from 'cors';
+import { db, init } from './db.js';
+
+init();
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+// Seed some jobs if table empty
+const seedJobs = () => {
+  db.get('SELECT COUNT(*) as count FROM jobs', (err, row) => {
+    if (row && row.count === 0) {
+      const stmt = db.prepare('INSERT INTO jobs (title, companyName, location, salary, jobPostedOn, hiringMultipleCandidates, niche) VALUES (?, ?, ?, ?, ?, ?, ?)');
+      const now = new Date().toISOString();
+      stmt.run('Frontend Developer', 'TechCorp', 'Colombo', 150000, now, 'Yes', 'Web Development');
+      stmt.run('Backend Engineer', 'CodeWorks', 'Kandy', 140000, now, 'No', 'Software Development');
+      stmt.run('Cloud Architect', 'SkyNet', 'Galle', 180000, now, 'Yes', 'Cloud Computing');
+      stmt.finalize();
+    }
+  });
+};
+seedJobs();
+
+app.get('/jobs', (req, res) => {
+  db.all('SELECT * FROM jobs', (err, rows) => {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json(rows);
+  });
+});
+
+app.post('/register', (req, res) => {
+  const { email, password, role } = req.body;
+  const stmt = db.prepare('INSERT INTO users (email, password, role) VALUES (?, ?, ?)');
+  stmt.run(email, password, role, function(err) {
+    if (err) return res.status(400).json({ error: err.message });
+    res.json({ id: this.lastID, email, role });
+  });
+});
+
+app.post('/login', (req, res) => {
+  const { email, password } = req.body;
+  db.get('SELECT email, role FROM users WHERE email = ? AND password = ?', [email, password], (err, row) => {
+    if (err) return res.status(500).json({ error: err.message });
+    if (!row) return res.status(401).json({ error: 'Invalid credentials' });
+    res.json(row);
+  });
+});
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "job-backend",
+  "version": "1.0.0",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "sqlite3": "^5.1.7",
+    "cors": "^2.8.5"
+  }
+}

--- a/project/src/context/AuthContext.tsx
+++ b/project/src/context/AuthContext.tsx
@@ -7,8 +7,8 @@ interface User {
 
 interface AuthContextType {
   user: User | null;
-  login: (email: string, role: string) => void;
-  register: (email: string, role: string) => void;
+  login: (email: string, password: string) => Promise<void>;
+  register: (email: string, password: string, role: string) => Promise<void>;
   logout: () => void;
 }
 
@@ -20,14 +20,26 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     return stored ? JSON.parse(stored) : null;
     });
 
-  const login = (email: string, role: string) => {
-    const newUser = { email, role };
+  const login = async (email: string, password: string) => {
+    const res = await fetch("http://localhost:3001/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password }),
+    });
+    if (!res.ok) throw new Error("Login failed");
+    const newUser = await res.json();
     setUser(newUser);
     localStorage.setItem("user", JSON.stringify(newUser));
   };
 
-  const register = (email: string, role: string) => {
-    login(email, role);
+  const register = async (email: string, password: string, role: string) => {
+    const res = await fetch("http://localhost:3001/register", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password, role }),
+    });
+    if (!res.ok) throw new Error("Registration failed");
+    await login(email, password);
   };
 
   const logout = () => {

--- a/project/src/pages/Jobs.tsx
+++ b/project/src/pages/Jobs.tsx
@@ -1,10 +1,10 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { motion } from "framer-motion";
 import { Search, MapPin, Filter, Calendar, DollarSign, Building2 } from "lucide-react";
 import Button from "../components/ui/Button";
 
 interface Job {
-  _id: string;
+  id: number;
   title: string;
   companyName: string;
   location: string;
@@ -14,45 +14,13 @@ interface Job {
   niche: string;
 }
 
-const jobsData: Job[] = [
-  {
-    _id: "1",
-    title: "Frontend Developer",
-    companyName: "TechCorp",
-    location: "Colombo",
-    salary: 150000,
-    jobPostedOn: new Date().toISOString(),
-    hiringMultipleCandidates: "Yes",
-    niche: "Web Development",
-  },
-  {
-    _id: "2",
-    title: "Backend Engineer",
-    companyName: "CodeWorks",
-    location: "Kandy",
-    salary: 140000,
-    jobPostedOn: new Date().toISOString(),
-    hiringMultipleCandidates: "No",
-    niche: "Software Development",
-  },
-  {
-    _id: "3",
-    title: "Cloud Architect",
-    companyName: "SkyNet",
-    location: "Galle",
-    salary: 180000,
-    jobPostedOn: new Date().toISOString(),
-    hiringMultipleCandidates: "Yes",
-    niche: "Cloud Computing",
-  },
-];
-
 const Jobs = () => {
   const [city, setCity] = useState("All");
   const [niche, setNiche] = useState("All");
   const [searchKeyword, setSearchKeyword] = useState("");
   const [showFilters, setShowFilters] = useState(false);
-  const [filteredJobs, setFilteredJobs] = useState<Job[]>(jobsData);
+  const [jobs, setJobs] = useState<Job[]>([]);
+  const [filteredJobs, setFilteredJobs] = useState<Job[]>([]);
 
   const cities = [
     "All",
@@ -102,8 +70,18 @@ const Jobs = () => {
     "IT Consulting",
   ];
 
+  useEffect(() => {
+    const fetchJobs = async () => {
+      const res = await fetch("http://localhost:3001/jobs");
+      const data = await res.json();
+      setJobs(data);
+      setFilteredJobs(data);
+    };
+    fetchJobs();
+  }, []);
+
   const handleSearch = () => {
-    const filtered = jobsData.filter((job) => {
+    const filtered = jobs.filter((job) => {
       const matchCity = city === "All" || job.location === city;
       const matchNiche = niche === "All" || job.niche === niche;
       const keyword = searchKeyword.toLowerCase();
@@ -262,7 +240,7 @@ const Jobs = () => {
               {filteredJobs && filteredJobs.length > 0 ? (
                 filteredJobs.map((job, index) => (
                   <motion.div
-                    key={job._id}
+                    key={job.id}
                     variants={itemVariants}
                     whileHover={{
                       y: -5,
@@ -323,7 +301,7 @@ const Jobs = () => {
 
                     <div className="mt-6 flex justify-end">
                       <Button
-                        href={`/post/application/${job._id}`}
+                        href={`/post/application/${job.id}`}
                         size="sm"
                         className="group-hover:shadow-lg transition-shadow duration-200"
                       >

--- a/project/src/pages/Login.tsx
+++ b/project/src/pages/Login.tsx
@@ -6,7 +6,6 @@ import Button from "../components/ui/Button";
 import { useAuth } from "../context/AuthContext";
 
 const Login = () => {
-  const [role, setRole] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
@@ -14,13 +13,17 @@ const Login = () => {
   const { login } = useAuth();
   const navigateTo = useNavigate();
 
-  const handleLogin = (e: React.FormEvent) => {
+  const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
-    // In a real app you'd verify credentials here
-    login(email, role);
-    setLoading(false);
-    navigateTo("/");
+    try {
+      await login(email, password);
+      navigateTo("/");
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
@@ -57,28 +60,6 @@ const Login = () => {
               transition={{ delay: 0.3, duration: 0.6 }}
             >
               <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
-                Login As
-              </label>
-              <div className="relative">
-                <User className="absolute left-4 top-1/2 transform -translate-y-1/2 w-5 h-5 text-slate-400" />
-                <select
-                  value={role}
-                  onChange={(e) => setRole(e.target.value)}
-                  className="w-full pl-12 pr-4 py-4 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500/50 transition-all duration-200"
-                >
-                  <option value="">Select Role</option>
-                  <option value="Employer">Login as an Employer</option>
-                  <option value="Job Seeker">Login as a Job Seeker</option>
-                </select>
-              </div>
-            </motion.div>
-
-            <motion.div
-              initial={{ opacity: 0, x: -20 }}
-              animate={{ opacity: 1, x: 0 }}
-              transition={{ delay: 0.4, duration: 0.6 }}
-            >
-              <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
                 Email Address
               </label>
               <div className="relative">
@@ -96,7 +77,7 @@ const Login = () => {
             <motion.div
               initial={{ opacity: 0, x: -20 }}
               animate={{ opacity: 1, x: 0 }}
-              transition={{ delay: 0.5, duration: 0.6 }}
+              transition={{ delay: 0.4, duration: 0.6 }}
             >
               <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
                 Password

--- a/project/src/pages/Register.tsx
+++ b/project/src/pages/Register.tsx
@@ -14,12 +14,17 @@ const Register = () => {
   const { register } = useAuth();
   const navigateTo = useNavigate();
 
-  const handleRegister = (e: React.FormEvent) => {
+  const handleRegister = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
-    register(email, role);
-    setLoading(false);
-    navigateTo("/");
+    try {
+      await register(email, password, role);
+      navigateTo("/");
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- add Express server with SQLite tables for jobs and users
- fetch job listings and auth data from the new API instead of in-memory samples
- add root `.gitignore`
- move server code into a dedicated `backend` directory

## Testing
- `cd project && npm test` (fails: Missing script: "test")
- `cd project && npm run build` (fails: Rollup failed to resolve import "react-router-dom")
- `cd backend && npm install` (fails: 403 Forbidden)
- `cd project && npm install` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68b2aee6c6c48331951bf8c6dcc5b504