### PR TITLE
Seed database with 100 job records

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -8,15 +8,74 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 
-// Seed some jobs if table empty
+// Seed 100 different jobs if table empty
 const seedJobs = () => {
   db.get('SELECT COUNT(*) as count FROM jobs', (err, row) => {
     if (row && row.count === 0) {
-      const stmt = db.prepare('INSERT INTO jobs (title, companyName, location, salary, jobPostedOn, hiringMultipleCandidates, niche) VALUES (?, ?, ?, ?, ?, ?, ?)');
+      const stmt = db.prepare(
+        'INSERT INTO jobs (title, companyName, location, salary, jobPostedOn, hiringMultipleCandidates, niche) VALUES (?, ?, ?, ?, ?, ?, ?)'
+      );
       const now = new Date().toISOString();
-      stmt.run('Frontend Developer', 'TechCorp', 'Colombo', 150000, now, 'Yes', 'Web Development');
-      stmt.run('Backend Engineer', 'CodeWorks', 'Kandy', 140000, now, 'No', 'Software Development');
-      stmt.run('Cloud Architect', 'SkyNet', 'Galle', 180000, now, 'Yes', 'Cloud Computing');
+
+      const roles = [
+        'Software Engineer',
+        'Data Scientist',
+        'Product Manager',
+        'UX Designer',
+        'QA Engineer',
+        'DevOps Engineer',
+        'System Administrator',
+        'Database Administrator',
+        'Network Engineer',
+        'Security Analyst',
+        'Technical Writer',
+        'Business Analyst',
+        'Scrum Master',
+        'Graphic Designer',
+        'Web Developer',
+        'Mobile Developer',
+        'AI Researcher',
+        'Machine Learning Engineer',
+        'Cloud Architect',
+        'IT Support Specialist'
+      ];
+      const levels = ['Intern', 'Junior', 'Mid-level', 'Senior', 'Lead'];
+      const companies = [
+        'TechCorp',
+        'CodeWorks',
+        'SkyNet',
+        'CloudNine',
+        'InnovateX',
+        'DataMinds',
+        'NextGen',
+        'DevMasters',
+        'AlphaBeta',
+        'QuantumSoft'
+      ];
+      const locations = [
+        'Colombo',
+        'Kandy',
+        'Galle',
+        'Jaffna',
+        'Negombo',
+        'Matara',
+        'Kurunegala',
+        'Batticaloa',
+        'Anuradhapura',
+        'Trincomalee'
+      ];
+
+      roles.forEach((role, i) => {
+        levels.forEach((level, j) => {
+          const title = `${level} ${role}`;
+          const company = companies[(i + j) % companies.length];
+          const location = locations[(i * levels.length + j) % locations.length];
+          const salary = 50000 + ((i * levels.length + j) * 1000);
+          const hiring = (i + j) % 2 === 0 ? 'Yes' : 'No';
+          const niche = role;
+          stmt.run(title, company, location, salary, now, hiring, niche);
+        });
+      });
       stmt.finalize();
     }
   });

--- a/project/src/data/jobs.ts
+++ b/project/src/data/jobs.ts
@@ -1,0 +1,74 @@
+import { Job } from "../types";
+
+const roles = [
+  "Software Engineer",
+  "Data Scientist",
+  "Product Manager",
+  "UX Designer",
+  "QA Engineer",
+  "DevOps Engineer",
+  "System Administrator",
+  "Database Administrator",
+  "Network Engineer",
+  "Security Analyst",
+  "Technical Writer",
+  "Business Analyst",
+  "Scrum Master",
+  "Graphic Designer",
+  "Web Developer",
+  "Mobile Developer",
+  "AI Researcher",
+  "Machine Learning Engineer",
+  "Cloud Architect",
+  "IT Support Specialist"
+];
+
+const levels = ["Intern", "Junior", "Mid-level", "Senior", "Lead"];
+const companies = [
+  "TechCorp",
+  "CodeWorks",
+  "SkyNet",
+  "CloudNine",
+  "InnovateX",
+  "DataMinds",
+  "NextGen",
+  "DevMasters",
+  "AlphaBeta",
+  "QuantumSoft"
+];
+
+const locations = [
+  "Colombo",
+  "Kandy",
+  "Galle",
+  "Jaffna",
+  "Negombo",
+  "Matara",
+  "Kurunegala",
+  "Batticaloa",
+  "Anuradhapura",
+  "Trincomalee"
+];
+
+export const dummyJobs: Job[] = (() => {
+  const jobs: Job[] = [];
+  const now = new Date().toISOString();
+  let id = 1;
+
+  roles.forEach((role, i) => {
+    levels.forEach((level, j) => {
+      jobs.push({
+        id: id++,
+        title: `${level} ${role}`,
+        companyName: companies[(i + j) % companies.length],
+        location: locations[(i * levels.length + j) % locations.length],
+        salary: 50000 + ((i * levels.length + j) * 1000),
+        jobPostedOn: now,
+        hiringMultipleCandidates: (i + j) % 2 === 0 ? "Yes" : "No",
+        niche: role
+      });
+    });
+  });
+
+  return jobs;
+})();

--- a/project/src/pages/Jobs.tsx
+++ b/project/src/pages/Jobs.tsx
@@ -2,17 +2,8 @@ import React, { useState, useEffect } from "react";
 import { motion } from "framer-motion";
 import { Search, MapPin, Filter, Calendar, DollarSign, Building2 } from "lucide-react";
 import Button from "../components/ui/Button";
-
-interface Job {
-  id: number;
-  title: string;
-  companyName: string;
-  location: string;
-  salary: number;
-  jobPostedOn: string;
-  hiringMultipleCandidates: "Yes" | "No";
-  niche: string;
-}
+import { Job } from "../types";
+import { dummyJobs } from "../data/jobs";
 
 const Jobs = () => {
   const [city, setCity] = useState("All");
@@ -71,13 +62,8 @@ const Jobs = () => {
   ];
 
   useEffect(() => {
-    const fetchJobs = async () => {
-      const res = await fetch("http://localhost:3001/jobs");
-      const data = await res.json();
-      setJobs(data);
-      setFilteredJobs(data);
-    };
-    fetchJobs();
+    setJobs(dummyJobs);
+    setFilteredJobs(dummyJobs);
   }, []);
 
   const handleSearch = () => {

--- a/project/src/types.ts
+++ b/project/src/types.ts
@@ -1,0 +1,10 @@
+export interface Job {
+  id: number;
+  title: string;
+  companyName: string;
+  location: string;
+  salary: number;
+  jobPostedOn: string;
+  hiringMultipleCandidates: "Yes" | "No";
+  niche: string;
+}


### PR DESCRIPTION
## Summary
- expand backend seeding to generate 100 job entries across multiple roles and levels
- remove checked-in SQLite database and rely on runtime seeding
- load ~100 dummy jobs directly on the browse page for frontend testing

## Testing
- `cd backend && npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cors)*
- `npm test` *(fails: Missing script "test")*
- `node index.js` *(fails: Cannot find package 'express')*
- `cd ../project && npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-router-dom)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b2b375bf8c8331b48aa0859e8396ef